### PR TITLE
Chore: Refactor engine, to be simpler to explain and read.

### DIFF
--- a/examples/calc/Calc.mo
+++ b/examples/calc/Calc.mo
@@ -149,6 +149,12 @@ public class Calc() {
     }
   };
 
+  public func showLog(l : Engine.Log<Name, Val, Error, Exp>) : Text {
+    var s = "<error:debug blocks required for Calc.showLog>";
+    debug { s := debug_show l };
+    s
+  };
+
   /* -- cache implementation, via adapton package -- */
 
   public var engine : Engine.Engine<Name, Val, Error, Exp> = do {
@@ -170,7 +176,6 @@ public class Calc() {
      true);
     engine
   };
-
 };
 
 }

--- a/src/Engine.mo
+++ b/src/Engine.mo
@@ -345,9 +345,9 @@ module {
                if (resultEq(oldRes, cleanRes)) {
                  e.dirtyFlag := false;
                  true // equal results ==> clean edge; reuse it edge.
-                } else {
-                  false // changed result ==> could not clean edge; must replace.
-                }
+               } else {
+                 false // changed result ==> could not clean edge; must replace.
+               }
              };
         case (_, _) {
                loop { assert false }

--- a/src/Engine.mo
+++ b/src/Engine.mo
@@ -15,6 +15,8 @@ import Lg "types/Log";
 import Log "Log";
 
 module {
+  public type Log<Name, Val, Error, Closure> = [Log.LogEvent<Name, Val, Error, Closure>];
+
   // class accepts the associated operations over the 4 user-defined type params; See usage instructions in `types/Eval` module
   public class Engine<Name, Val, Error, Closure>
   (
@@ -152,32 +154,13 @@ module {
              #ok(res)
            };
       case (?#thunk(thunkNode)) {
-             switch (thunkNode.result) {
-             case null {
-                    let res = evalThunk(c, name, thunkNode);
-                    logEnd(c, #get(name, res));
-                    addEdge(c, name, #get(res));
-                    #ok(res)
-                  };
-             case (?oldResult) {
-                    if (thunkIsDirty(thunkNode)) {
-                      if(cleanThunk(c, name, thunkNode)) {
-                        logEnd(c, #get(name, oldResult));
-                        addEdge(c, name, #get(oldResult));
-                        #ok(oldResult)
-                      } else {
-                        let res = evalThunk(c, name, thunkNode);
-                        logEnd(c, #get(name, res));
-                        addEdge(c, name, #get(res));
-                        #ok(res)
-                      }
-                    } else {
-                      logEnd(c, #get(name, oldResult));
-                      addEdge(c, name, #get(oldResult));
-                      #ok(oldResult)
-                    }
-                  };
-             }
+             let getRes = switch (thunkNode.result) {
+               case null { evalThunk(c, name, thunkNode) };
+               case (?_) { cleanThunk(c, name, thunkNode) };
+             };
+             addEdge(c, name, #get(getRes));
+             logEnd(c, #get(name, getRes));
+             #ok(getRes)
            };
       }
     };
@@ -327,14 +310,6 @@ module {
       }
     };
 
-    func optionResultEq (r1:?{#ok:Val; #err:Error}, r2:?{#ok:Val; #err:Error}) : Bool {
-      switch (r1, r2) {
-        case (null, null) { true };
-        case (?r1, ?r2) { resultEq(r1, r2) };
-        case _ { false };
-      }
-    };
-
     func resultEq (r1:{#ok:Val; #err:Error}, r2:{#ok:Val; #err:Error}) : Bool {
       switch (r1, r2) {
         case (#ok(v1), #ok(v2)) { evalOps.valEq(v1, v2) };
@@ -366,22 +341,13 @@ module {
                } else { false }
              };
         case (#get(oldRes), ?#thunk(thunkNode)) {
-               if (not cleanThunk(c, e.dependency, thunkNode)) {
-                 ignore evalThunk(c, e.dependency, thunkNode);
-               };
-               // now, we care about
-               // equality test of old observation vs latest observation on edge,
-               // post-cleaning, regardless of cases above.
-               let thunkNode2 = switch(c.store.get(e.dependency)) {
-                 case (?#thunk(tn)) { tn };
-                 case _ { loop { assert false } };
-               };
-               if (optionResultEq(?oldRes, thunkNode2.result)) {
+               let cleanRes = cleanThunk(c, e.dependency, thunkNode);
+               if (resultEq(oldRes, cleanRes)) {
                  e.dirtyFlag := false;
                  true // equal results ==> clean edge; reuse it edge.
-               } else {
-                 false // changed result ==> could not clean edge; must replace.
-               }
+                } else {
+                  false // changed result ==> could not clean edge; must replace.
+                }
              };
         case (_, _) {
                loop { assert false }
@@ -394,26 +360,31 @@ module {
       successFlag;
     };
 
-    func cleanThunk(c:G.Context<Name, Val, Error, Closure>, n:Name, t:G.Thunk<Name, Val, Error, Closure>) : Bool {
+    func cleanThunk(c:G.Context<Name, Val, Error, Closure>, n:Name, t:G.Thunk<Name, Val, Error, Closure>) : R.Result<Val, Error> {
       logBegin(c);
-      if (switch(t.result) { case null true; case _ false }) {
-        // no cache result and in demand ==> we must evaluate thunk (from scratch):
-        // now the thunk is "clean" (always an invariant post evaluation).
-        ignore evalThunk(c, n, t);
-        logEnd(c, #cleanThunk(n, true));
-        return true
-      } else {
-        for (i in t.outgoing.keys()) {
-          if (cleanEdge(c, t.outgoing[i])) {
-            /* continue */
-          } else {
-            logEnd(c, #cleanThunk(n, false));
-            return false // outgoing[i] could not be cleaned.
-          }
-        }
-      };
-      logEnd(c, #cleanThunk(n, true));
-      true
+      switch(t.result) {
+        case null {
+          // no cache result and in demand ==> we must evaluate thunk (from scratch):
+          // now the thunk is "clean" (always an invariant post evaluation).
+          let res = evalThunk(c, n, t);
+          logEnd(c, #cleanThunk(n, false)); // false because no dep graph to clean
+          res
+        };
+        case (?oldRes) {
+          for (i in t.outgoing.keys()) {
+            if (cleanEdge(c, t.outgoing[i])) {
+              /* continue */
+            } else {
+              let res = evalThunk(c, n, t);
+              logEnd(c, #cleanThunk(n, false)); // false because we could not clean edge
+              return res
+            }
+          };
+          // cleaning success: old result and its dep graph is consistent.
+          logEnd(c, #cleanThunk(n, true));
+          oldRes
+       };
+      }
     };
 
     func stackContainsNodeName(s:G.Stack<Name>, nodeName:Name) : Bool {

--- a/src/Log.mo
+++ b/src/Log.mo
@@ -9,6 +9,9 @@ import L "mo:base/List";
 
 module {
 
+  public type Log<Name, Val, Error, Closure> =
+    [LogEvent<Name, Val, Error, Closure>];
+
   public type LogEvent<Name, Val, Error, Closure> =
     Log.LogEvent<Name, Val, Error, Closure>;
 
@@ -58,7 +61,7 @@ module {
       }
     };
 
-    public func take() : [LogEvent<Name, Val, Error, Closure>] {
+    public func take() : Log<Name, Val, Error, Closure> {
       assert logFlag;
       assert L.isNil(logStack);
       let events = logBuf.toArray();


### PR DESCRIPTION
- reduces total line count, and the conceptual complexity, by consolidating key choices during "getting" and "cleaning" thunks.
- engine logic no longer asks whether thunks are clean or not, it merely tries to clean them if they have a result
- logs are more informative, and better resemble the logic of the engine to justify its actions and effects
  - the `Main.mo` file in this PR shows how the logs change with the new engine semantics:
  - when a thunk is cleaned, successfully or not, explicitly list each edge that is visited to be cleaned
  - when a thunk is cleaned by evaluation, use the flag `false`, since `true` should mean only that all edges were successfully cleaned, and the result is (already) consistent; and for the future, consider a variant in place of `Bool` for the three outcomes (`{#clean, #reeval, #eval}` for the `true` and two false cases that involve evaluation.