### PR TITLE
Chore: simplify Engine and main Calc example

### DIFF
--- a/examples/calc/Calc.mo
+++ b/examples/calc/Calc.mo
@@ -37,46 +37,30 @@ public type Exp = { // *
 // simple integer-based calculator, with incremental caching
 public class Calc() {
 
-  /* -- utils -- extra stuff we need -- */
+  /* -- cache implementation, via adapton package -- */
+  public var engine : Engine.Engine<Name, Val, Error, Exp> =
+    Engine.Engine<Name, Val, Error, Exp>(
+      {
+        nameEq=func (x:Text, y:Text) : Bool { x == y };
+        valEq=func (x:Int, y:Int) : Bool { x == y };
+        closureEq=func (x:Exp, y:Exp) : Bool { x == y };
+        errorEq=func (x:Error, y:Error) : Bool { x == y };
+        nameHash=Text.hash;
+        cyclicDependency=func (stack:L.List<Name>, name:Name) : Error {
+          assert false; loop { }
+        }
+      },
+      true // logging
+    );
 
-  public func binOpOfExp(e:Exp)
-    : ?{#add;#sub;#mul;#div} {
-    switch e {
-    case (#add _) ?#add;
-    case (#sub _) ?#sub;
-    case (#mul _) ?#mul;
-    case (#div _) ?#div;
-    case _ null;
-    }
-  };
+  public var engineIsInit = false;
 
-  func expEq(x:Exp, y:Exp) : Bool {
-    x == y
-  };
-
-  func errorEq(x:Error, y:Error) : Bool {
-    x == y
-  };
-
-  /* -- custom DSL evaluator definition: -- */
-
-  var init : Bool = false;
-
-  public func eval(e:Exp) : R.Result<Val, Error> {
-    if (not init) {
-      // Adapton engine step 3:
-      //   initialize engine with evaluation function.
-      engine.setEvalClosure({eval=evalRec});
-      // Now the the calculator is ready for (incremental) evaluation!
-      init := true;
-    };
-    let e_ = alloc(e);
-    evalRec(e_)
-  };
-
-  // Allocate the AST into the Engine, so that #ref AST nodes are used in place of #named nodes.
-  // Later, we can do fine-grained changes, using just those names.
-  public func alloc(e : Exp) : Exp {
+  /// Pre-evaluation allocation step.
+  ///
+  /// To permit fine-grained changes and re-execution,
+  /// first allocate the AST nodes into the Engine as thunks,
+  /// before evaluating them.
+  func alloc(e : Exp) : Exp {
     switch e {
       case (#num(n)) { #num(n) };
       case (#thunk(n)) { #thunk((n)) };
@@ -93,39 +77,54 @@ public class Calc() {
     }
   };
 
-  // Adapton engine step 2:
-  //    Using engine as a cache, define a custom evaluation function for DSL:
-  func evalRec(e:Exp) : R.Result<Val, Error> {
+  func binOpOfExp(e:Exp)
+    : ?{#add;#sub;#mul;#div} {
     switch e {
-    case (#num(n)) { #ok(n) };
-    case ( #add(_, _) // feedback to compiler design: This would be easier if I could bind vars here.
-        or #sub(_, _)
-        or #mul(_, _)
-        or #div(_, _) ) {
-           switch (evalEagerPair(e)) {
-             case (#err(e)) #err(e);
-             case (#ok((n1, n2))) {
-                    switch (binOpOfExp(e)) {
-                    case null { loop { assert false } };
-                    case (?#add) #ok(n1 + n2) ;
-                    case (?#mul) #ok(n1 * n2);
-                    case (?#sub) #ok(n1 - n2);
-                    case (?#div) if (n2 == 0) { #err(#divByZero) } else #ok(n1 / n2);
-                  }
-                  }
-           }
-         };
-    case (#alloc(n, e)) { loop { assert false }  };
-    case (#thunk(n)) {
-           switch (engine.get(n)) {
-           case (#ok(res)) { res }; // temp
-           case (#err(_)) { #err(#getError(n)) };
-           }
-         };
+    case (#add _) ?#add;
+    case (#sub _) ?#sub;
+    case (#mul _) ?#mul;
+    case (#div _) ?#div;
+    case _ null;
     }
   };
 
-  func evalEagerPair(e:Exp) : R.Result<(Val, Val), Error> {
+  public func eval(exp : Exp) : R.Result<Val, Error> {
+    if (not engineIsInit) {
+      engine.init({eval=evalRec});
+      engineIsInit := true
+    };
+    let exp_ = alloc(exp);
+    evalRec(exp_)
+  };
+
+  func evalRec(exp : Exp) : R.Result<Val, Error> {
+    switch exp {
+    case (#num(n)) { #ok(n) };
+    case (#alloc(n, e)) { loop { assert false }  };
+    case (#thunk(n)) {
+      switch (engine.get(n)) {
+        case (#ok(res)) { res }; // temp
+        case (#err(_)) { #err(#getError(n)) };
+      }
+    };
+    case _ {
+      switch (evalBinopArgs(exp)) {
+        case (#err(e)) #err(e);
+        case (#ok((n1, n2))) {
+          switch (binOpOfExp(exp)) {
+            case null { loop { assert false } };
+            case (?#add) #ok(n1 + n2) ;
+            case (?#mul) #ok(n1 * n2);
+            case (?#sub) #ok(n1 - n2);
+            case (?#div) if (n2 == 0) { #err(#divByZero) } else #ok(n1 / n2);
+          }
+        }
+      }
+     };
+    }
+  };
+
+  func evalBinopArgs(e:Exp) : R.Result<(Val, Val), Error> {
     func doit(e1:Exp, e2:Exp) : R.Result<(Val, Val), Error> {
       switch (evalRec(e1)) {
       case (#err(e)) #err(e);
@@ -140,7 +139,6 @@ public class Calc() {
       }
     };
     switch e {
-      // redoing the pattern-match because I cannot bind vars in `or` patterns
       case (#add(e1, e2)) { doit(e1, e2) };
       case (#sub(e1, e2)) { doit(e1, e2) };
       case (#div(e1, e2)) { doit(e1, e2) };
@@ -149,33 +147,13 @@ public class Calc() {
     }
   };
 
-  public func showLog(l : Engine.Log<Name, Val, Error, Exp>) : Text {
-    var s = "<error:debug blocks required for Calc.showLog>";
-    debug { s := debug_show l };
-    s
+  public func takeLog() : Engine.Log<Name, Val, Error, Exp> {
+    let log = engine.takeLog();
+    debug { Debug.print (debug_show log) };
+    log
   };
 
-  /* -- cache implementation, via adapton package -- */
 
-  public var engine : Engine.Engine<Name, Val, Error, Exp> = do {
-    let _errorEq = errorEq;
-    // Adapton engine step 1b:
-    //   Apply the engine to the definitions of types and operations,
-    //   excluding the definition of evaluation itself (step 2).
-    let engine = Engine.Engine<Name, Val, Error, Exp>
-    ({
-       nameEq=func (x:Text, y:Text) : Bool { x == y };
-       valEq=func (x:Int, y:Int) : Bool { x == y };
-       errorEq=_errorEq;
-       closureEq=expEq;
-       nameHash=Text.hash;
-       cyclicDependency=func (stack:L.List<Name>, name:Name) : Error {
-         assert false; loop { }
-       }
-     },
-     true);
-    engine
-  };
 };
 
 }

--- a/examples/calc/Main.mo
+++ b/examples/calc/Main.mo
@@ -19,7 +19,7 @@ actor {
     do /* initial run */ {
       let res1 = calc.eval(exp);
       debug { Debug.print(testStep # "Assert first evaluation.") };
-      assert calc.engine.takeLog() == [
+      assert calc.takeLog() == [
         #putThunk("h", #num(+2), []),
         #putThunk("g", #div(#num(+4), #mul(#num(+6), #thunk("h"))), []),
         #putThunk("c", #add(#num(+1), #num(+2)), []),
@@ -48,7 +48,7 @@ actor {
 
       debug { Debug.print(testStep # "Assert re-get.") };
       ignore calc.engine.get("f");
-      assert calc.engine.takeLog() ==
+      assert calc.takeLog() ==
         [#get("f", #ok(+3),
         [#cleanThunk("f", true,
         [#cleanEdgeTo("g", true, []),
@@ -56,7 +56,7 @@ actor {
 
       debug { Debug.print(testStep # "Assert share.") };
       ignore calc.eval(#alloc("k", #add(#thunk("g"), #num(3))));
-      assert calc.engine.takeLog() ==
+      assert calc.takeLog() ==
         [#putThunk("k", #add(#thunk("g"), #num(+3)), []),
          #get("k", #ok(+3),
         [#evalThunk("k", #ok(+3),
@@ -68,7 +68,7 @@ actor {
     do /* input change (overwrite "g"), and re-demand output value (of "f") */ {
       ignore calc.engine.putThunk("g", #add(#num(1), #num(2)));
       debug { Debug.print(testStep # "Assert input change: Overwrite thunk with putThunk.") };
-      assert calc.engine.takeLog() ==
+      assert calc.takeLog() ==
         [#putThunk("g", #add(#num(+1), #num(+2)),
                    [#dirtyIncomingTo("g",
                    [#dirtyEdgeFrom("f",
@@ -78,7 +78,7 @@ actor {
 
       let res3 = calc.engine.get("f");
       debug { Debug.print(testStep # "Assert change propagation: Reuse clean graph") };
-      assert calc.engine.takeLog() ==
+      assert calc.takeLog() ==
         [#get("f", #ok(+6),
         [#cleanThunk("f", false,
         [#cleanEdgeTo("g", false,
@@ -96,7 +96,7 @@ actor {
     do /* input change with same valuation ("g"'s new  expression has same value) */ {
       ignore calc.engine.putThunk("g", #add(#num(3), #num(0)));
       debug { Debug.print(testStep # "Assert input change: Overwrite thunk with putThunk, again.") };
-      assert calc.engine.takeLog() ==
+      assert calc.takeLog() ==
       [#putThunk("g", #add(#num(+3), #num(0)),
         [#dirtyIncomingTo("g",
         [#dirtyEdgeFrom("f",
@@ -104,7 +104,7 @@ actor {
 
       let res3 = calc.engine.get("f");
       debug { Debug.print(testStep # "Assert change propagation: Clean and reuse (most of) graph") };
-      assert calc.engine.takeLog() ==
+      assert calc.takeLog() ==
         [#get("f", #ok(+6),
         [#cleanThunk("f", true,
         [#cleanEdgeTo("g", true,
@@ -116,7 +116,7 @@ actor {
     do /* re-demand "k", and re-use cleaning from above (of "g"), though the value changed. */ {
       let res3 = calc.engine.get("k");
       debug { Debug.print(testStep # "Assert change propagation: Reuse clean graph") };
-      assert calc.engine.takeLog() ==
+      assert calc.takeLog() ==
         [#get("k", #ok(+6),
         [#cleanThunk("k", false,
         [#cleanEdgeTo("g", false,

--- a/src/types/Eval.mo
+++ b/src/types/Eval.mo
@@ -30,9 +30,11 @@ module {
  To resolve this cycle, the Adapton client does three steps, not one:
 
  a. Defines the items mentioned in question 1 above, and applies the
-    Adapton.Engine functor to get an initial cache representation.  This
-    representation is only half-defined, however: It still has no way to
-    perform Closure evaluation.  Steps (b) and (c) are still needed below.
+    Adapton.Engine class constructor to get an initial cache representation.
+
+    This representation is mostly, but not fully, initiallized:
+    It still has no way to  perform Closure evaluation.
+    Steps (b) and (c) are still needed below.
 
  b. Defines the evaluation function required by item 2 above,
     using the cache just defined in item (a).
@@ -43,7 +45,7 @@ module {
  Now, the evaluation function in step (b) is fully-defined,
  and it is ready to use the cache provided by the adapton package.
 
- See tests dir for an example.
+ See `examples/calc` for a working example.
 
 */
 

--- a/src/types/Graph.mo
+++ b/src/types/Graph.mo
@@ -57,13 +57,13 @@ module {
   public type GetError = (); // to do
 
   public type Context<Name, Val, Error, Closure> = {
-    var agent: {#editor; #archivist};
     var edges: EdgeBuf<Name, Val, Error, Closure>;
     var stack: Stack<Name>;
     var store: Store<Name, Val, Error, Closure>;
     var logOps : Log.LogOps<Name, Val, Error, Closure>;
-    // defined and supplied by the client:
+    // defined and supplied by the client as Engine class param:
     evalOps: E.EvalOps<Name, Val, Error, Closure>;
+    // write-once back-patching for closure evaluation
     var evalClosure: ?E.EvalClosure<Val, Error, Closure>;
   };
 }


### PR DESCRIPTION
- refactor `Calc` code, simplifying its reading
- (`Calc`'s regression tests in `Main` remain unchanged in this PR)
- remove `agent` field from `Engine`, simplifying it.
- tried to remove the second of the 2-step initialization of engine, but then re-remembered why we need it...
- ...so, this PR settles on simplifying how we name and explain the initialization of engine in the second step.
- improve regression test ergonomics for failing tests