### PR TITLE
Calc Example: Polish.

### DIFF
--- a/examples/calc/Calc.mo
+++ b/examples/calc/Calc.mo
@@ -9,34 +9,36 @@ import Debug "mo:base/Debug";
 import Text "mo:base/Text";
 
 
-/* # Example of using Adapton engine. */
+/**
+ Integer calculator example.
+ Uses adapton for incremental caching of formula results, like a spreadsheet engine.
+ */
 
-/* Adapton engine use -- step 1a:
-      Define four types (see *'s below), and operations: */
 module {
-public type Name = Text; // *
-public type Val = Int; // *
+public type Name = Text;
+public type Val = Int;
 
-public type Error = { // *
+public type Error = {
   #divByZero;
   #unimplemented;
   #putError : Name;
   #getError : Name;
 };
 
-public type Exp = { // *
+// Expresssions serve as "spreadsheet formula" for the calculator.
+public type Exp = {
+  // Adapton-specific cases
   #alloc: (Name, Exp); // reduces to #thunk case *before* evaluation, to permit fine-grained changes
+  #thunk: Name;
+  // Integers and some binary operations:
   #num: Int;
   #add: (Exp, Exp);
   #sub: (Exp, Exp);
   #mul: (Exp, Exp);
   #div: (Exp, Exp);
-  #thunk: Name;
 };
 
-// simple integer-based calculator, with incremental caching
 public class Calc() {
-
   /* -- cache implementation, via adapton package -- */
   public var engine : Engine.Engine<Name, Val, Error, Exp> =
     Engine.Engine<Name, Val, Error, Exp>(
@@ -52,41 +54,7 @@ public class Calc() {
       },
       true // logging
     );
-
   public var engineIsInit = false;
-
-  /// Pre-evaluation allocation step.
-  ///
-  /// To permit fine-grained changes and re-execution,
-  /// first allocate the AST nodes into the Engine as thunks,
-  /// before evaluating them.
-  func alloc(e : Exp) : Exp {
-    switch e {
-      case (#num(n)) { #num(n) };
-      case (#thunk(n)) { #thunk((n)) };
-      case (#add(e1, e2)) { #add(alloc e1, alloc e2) };
-      case (#sub(e1, e2)) { #sub(alloc e1, alloc e2) };
-      case (#mul(e1, e2)) { #mul(alloc e1, alloc e2) };
-      case (#div(e1, e2)) { #div(alloc e1, alloc e2) };
-      case (#alloc(n, e)) {
-        switch (engine.putThunk(n, alloc(e))) {
-        case (#err(err)) { loop { assert false } };
-        case (#ok(n)) { #thunk(n) };
-        }
-      }
-    }
-  };
-
-  func binOpOfExp(e:Exp)
-    : ?{#add;#sub;#mul;#div} {
-    switch e {
-    case (#add _) ?#add;
-    case (#sub _) ?#sub;
-    case (#mul _) ?#mul;
-    case (#div _) ?#div;
-    case _ null;
-    }
-  };
 
   public func eval(exp : Exp) : R.Result<Val, Error> {
     if (not engineIsInit) {
@@ -97,53 +65,76 @@ public class Calc() {
     evalRec(exp_)
   };
 
-  func evalRec(exp : Exp) : R.Result<Val, Error> {
-    switch exp {
-    case (#num(n)) { #ok(n) };
-    case (#alloc(n, e)) { loop { assert false }  };
-    case (#thunk(n)) {
-      switch (engine.get(n)) {
-        case (#ok(res)) { res }; // temp
-        case (#err(_)) { #err(#getError(n)) };
-      }
-    };
-    case _ {
-      switch (evalBinopArgs(exp)) {
-        case (#err(e)) #err(e);
-        case (#ok((n1, n2))) {
-          switch (binOpOfExp(exp)) {
-            case null { loop { assert false } };
-            case (?#add) #ok(n1 + n2) ;
-            case (?#mul) #ok(n1 * n2);
-            case (?#sub) #ok(n1 - n2);
-            case (?#div) if (n2 == 0) { #err(#divByZero) } else #ok(n1 / n2);
-          }
-        }
-      }
-     };
+  /// Allocation, performed before evaluation.
+  ///
+  /// To permit fine-grained changes and re-execution,
+  /// first allocate the AST nodes into the Engine as thunks,
+  /// before evaluating them.
+  func alloc(e : Exp) : Exp {
+    switch e {
+      case (#num(n)) #num(n);
+      case (#thunk(n)) #thunk((n));
+      case (#add(e1, e2)) #add(alloc e1, alloc e2);
+      case (#sub(e1, e2)) #sub(alloc e1, alloc e2);
+      case (#mul(e1, e2)) #mul(alloc e1, alloc e2);
+      case (#div(e1, e2)) #div(alloc e1, alloc e2);
+      case (#alloc(n, e))
+        switch (engine.putThunk(n, alloc(e))) {
+        case (#err(err)) { loop { assert false } };
+        case (#ok(n)) { #thunk(n) };
+      };
     }
   };
 
-  func evalBinopArgs(e:Exp) : R.Result<(Val, Val), Error> {
-    func doit(e1:Exp, e2:Exp) : R.Result<(Val, Val), Error> {
+  /// Main evaluation logic.
+  /// (Interpreter for spreadsheet formula.)
+  func evalRec(exp : Exp) : R.Result<Val, Error> {
+    switch exp {
+    case (#num(n)) #ok(n);
+    case (#alloc(n, e)) loop { assert false };
+    case (#thunk(n))
+      switch (engine.get(n)) {
+        case (#ok(res)) res; // temp
+        case (#err(_)) #err(#getError(n));
+      };
+    case _ evalBinop(exp);
+    }
+  };
+
+  /// evalBinop evaluates the binary forms in a uniform way,
+  /// using (standard) call-by-value, left-to-right evaluation order.
+  /// (same evaluation order as Motoko).
+  func evalBinop(e:Exp) : R.Result<Val, Error> {
+    func rec(e1:Exp, e2:Exp) : R.Result<(Val, Val), Error> {
       switch (evalRec(e1)) {
       case (#err(e)) #err(e);
       case (#ok(v1)) {
-             switch (evalRec(e2)) {
-             case (#err(e)) #err(e);
-             case (#ok(v2)) {
-                    #ok((v1, v2))
-                  }
-             }
-           }
+        switch (evalRec(e2)) {
+          case (#err(e)) #err(e);
+          case (#ok(v2)) #ok((v1, v2));
+        }
+       }
       }
     };
-    switch e {
-      case (#add(e1, e2)) { doit(e1, e2) };
-      case (#sub(e1, e2)) { doit(e1, e2) };
-      case (#div(e1, e2)) { doit(e1, e2) };
-      case (#mul(e1, e2)) { doit(e1, e2) };
+    let recRes =
+      switch e {
+      case (#add(e1, e2)) rec(e1, e2);
+      case (#sub(e1, e2)) rec(e1, e2);
+      case (#div(e1, e2)) rec(e1, e2);
+      case (#mul(e1, e2)) rec(e1, e2);
       case _ { loop { assert false } };
+    };
+    switch(recRes) {
+      case (#err(e)) #err(e);
+      case (#ok(n1, n2)) {
+        switch (e) {
+        case (#add _) #ok(n1 + n2) ;
+        case (#mul _) #ok(n1 * n2);
+        case (#sub _) #ok(n1 - n2);
+        case (#div _) if (n2 == 0) { #err(#divByZero) } else #ok(n1 / n2);
+        case _ { loop { assert false } };
+        }
+      };
     }
   };
 
@@ -152,7 +143,6 @@ public class Calc() {
     debug { Debug.print (debug_show log) };
     log
   };
-
 
 };
 


### PR DESCRIPTION
- Rewrite documentation comments, highlighting what is important
- Reorder functions and remove one by refactoring
- Use fewer characters of Motoko syntax, especially around `case` sub-expressions.